### PR TITLE
Implement dark mode

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -20,6 +20,7 @@
         "lucide-react": "^0.454.0",
         "mailgun-js": "^0.22.0",
         "next": "14.2.16",
+        "next-themes": "^0.4.6",
         "react": "^18",
         "react-dom": "^18",
         "stripe": "^17.3.1",
@@ -4423,6 +4424,16 @@
         "sass": {
           "optional": true
         }
+      }
+    },
+    "node_modules/next-themes": {
+      "version": "0.4.6",
+      "resolved": "https://registry.npmjs.org/next-themes/-/next-themes-0.4.6.tgz",
+      "integrity": "sha512-pZvgD5L0IEvX5/9GWyHMf3m8BKiVQwsCMHfoFosXtXBMnaS0ZnIJ9ST4b4NqLVKDEm8QBxoNNGNaBv2JNF6XNA==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "^16.8 || ^17 || ^18 || ^19 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17 || ^18 || ^19 || ^19.0.0-rc"
       }
     },
     "node_modules/next/node_modules/postcss": {

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "lucide-react": "^0.454.0",
     "mailgun-js": "^0.22.0",
     "next": "14.2.16",
+    "next-themes": "^0.4.6",
     "react": "^18",
     "react-dom": "^18",
     "stripe": "^17.3.1",

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -55,7 +55,7 @@
   }
 
   body {
-    @apply bg-white;
+    @apply bg-white dark:bg-background;
     background-image:
       radial-gradient(at 40% 20%, rgba(66, 133, 244, 0.1) 0px, transparent 50%),
       radial-gradient(at 80% 0%, rgba(155, 114, 203, 0.1) 0px, transparent 50%),

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -3,6 +3,7 @@ import localFont from "next/font/local";
 import "./globals.css";
 import Header from "../components/header";
 import { Footer } from "../components/footer";
+import { ThemeProvider } from "../components/theme-provider";
 
 const geistSans = localFont({
   src: "./fonts/GeistVF.woff",
@@ -26,11 +27,13 @@ export default function RootLayout({
   children: React.ReactNode;
 }>) {
   return (
-    <html lang="en">
+    <html lang="en" suppressHydrationWarning>
       <body className={`${geistSans.variable} ${geistMono.variable} antialiased`}>
-        <Header />
-        {children}
-        <Footer />
+        <ThemeProvider attribute="class" defaultTheme="system" enableSystem>
+          <Header />
+          {children}
+          <Footer />
+        </ThemeProvider>
       </body>
     </html>
   );

--- a/src/components/header.tsx
+++ b/src/components/header.tsx
@@ -1,5 +1,5 @@
 'use client'
-import { Mail, Menu } from 'lucide-react';
+import { Mail, Menu, Sun, Moon } from 'lucide-react';
 import Link from 'next/link';
 import { Button } from './ui/button';
 import {
@@ -8,10 +8,12 @@ import {
     SheetTrigger,
 } from "@/components/ui/sheet"
 import { useState } from 'react';
+import { useTheme } from 'next-themes';
 import { ContactModal } from './contact-modal';
 
 const Header = () => {
     const [isContactModalOpen, setIsContactModalOpen] = useState(false);
+    const { theme, setTheme } = useTheme();
     return (
         <header className="sticky top-0 z-50 w-full border-b bg-background/95 backdrop-blur supports-[backdrop-filter]:bg-background/60">
             <div className="container  mx-auto max-w-7xl flex h-16 items-center justify-between">
@@ -32,6 +34,18 @@ const Header = () => {
                             Contact
                             <Mail className="h-4 w-4" />
                         </Button>
+                        <Button
+                          variant="ghost"
+                          size="icon"
+                          aria-label="Toggle theme"
+                          onClick={() => setTheme(theme === 'dark' ? 'light' : 'dark')}
+                        >
+                          {theme === 'dark' ? (
+                            <Sun className="h-5 w-5" />
+                          ) : (
+                            <Moon className="h-5 w-5" />
+                          )}
+                        </Button>
                     </nav>
                     {/* Mobile Menu Button */}
                     <Sheet>
@@ -46,6 +60,18 @@ const Header = () => {
                                 <Link href="/portfolio" className="text-lg font-semibold">Projects</Link>
                                 <Link href="/aboutme" className="text-lg font-semibold">About Me</Link>
                                 <Link href="/content" className="text-lg font-semibold">Content</Link>
+                                <Button
+                                  variant="ghost"
+                                  size="icon"
+                                  aria-label="Toggle theme"
+                                  onClick={() => setTheme(theme === 'dark' ? 'light' : 'dark')}
+                                >
+                                  {theme === 'dark' ? (
+                                    <Sun className="h-5 w-5" />
+                                  ) : (
+                                    <Moon className="h-5 w-5" />
+                                  )}
+                                </Button>
                             </nav>
                         </SheetContent>
                     </Sheet>

--- a/src/components/hero-section.tsx
+++ b/src/components/hero-section.tsx
@@ -4,11 +4,13 @@ import Image from 'next/image'
 import { Button } from './ui/button'
 import { Input } from './ui/input'
 import { useState } from 'react'
+import { useTheme } from 'next-themes'
 import { AnimatedEmojiSequence } from './animated-emoji-sequence';
 
 
 const HeroSection = () => {
     const [email, setEmail] = useState('');
+    const { resolvedTheme } = useTheme();
 
     const handleSubmit = async (e: React.FormEvent) => {
         e.preventDefault();
@@ -71,7 +73,7 @@ const HeroSection = () => {
                     {/* Image container */}
                     <div className="relative rounded-lg overflow-hidden">
                         <Image
-                            src="/matt-kuda-gemini.png"
+                            src={resolvedTheme === 'dark' ? '/mattkuda-gradient2.png' : '/matt-kuda-gemini.png'}
                             alt="Matt Kuda"
                             width={500}
                             height={500}

--- a/src/components/theme-provider.tsx
+++ b/src/components/theme-provider.tsx
@@ -1,0 +1,8 @@
+'use client'
+
+import { ThemeProvider as NextThemesProvider } from 'next-themes'
+import type { ThemeProviderProps } from 'next-themes/dist/types'
+
+export function ThemeProvider({ children, ...props }: ThemeProviderProps) {
+  return <NextThemesProvider {...props}>{children}</NextThemesProvider>
+}


### PR DESCRIPTION
## Summary
- add next-themes and ThemeProvider component
- wire ThemeProvider in RootLayout
- add theme toggle buttons to header
- swap hero photo in dark mode
- tweak global body colors
- remove unused gemini image

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6840338ed1388328ab80b3934099418e