### PR TITLE
Enable dark mode toggle

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "next": "14.2.16",
     "react": "^18",
     "react-dom": "^18",
+    "next-themes": "^1.2.0",
     "stripe": "^17.3.1",
     "tailwind-merge": "^2.5.4",
     "tailwindcss-animate": "^1.0.7"

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -62,4 +62,12 @@
       radial-gradient(at 0% 50%, rgba(217, 101, 112, 0.1) 0px, transparent 50%);
     min-height: 100vh;
   }
+
+  .dark body {
+    @apply bg-background;
+    background-image:
+      radial-gradient(at 40% 20%, rgba(66, 133, 244, 0.2) 0px, transparent 50%),
+      radial-gradient(at 80% 0%, rgba(155, 114, 203, 0.2) 0px, transparent 50%),
+      radial-gradient(at 0% 50%, rgba(217, 101, 112, 0.2) 0px, transparent 50%);
+  }
 }

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -3,6 +3,7 @@ import localFont from "next/font/local";
 import "./globals.css";
 import Header from "../components/header";
 import { Footer } from "../components/footer";
+import { ThemeProvider } from "../components/theme-provider";
 
 const geistSans = localFont({
   src: "./fonts/GeistVF.woff",
@@ -28,9 +29,11 @@ export default function RootLayout({
   return (
     <html lang="en">
       <body className={`${geistSans.variable} ${geistMono.variable} antialiased`}>
-        <Header />
-        {children}
-        <Footer />
+        <ThemeProvider attribute="class">
+          <Header />
+          {children}
+          <Footer />
+        </ThemeProvider>
       </body>
     </html>
   );

--- a/src/components/header.tsx
+++ b/src/components/header.tsx
@@ -9,6 +9,7 @@ import {
 } from "@/components/ui/sheet"
 import { useState } from 'react';
 import { ContactModal } from './contact-modal';
+import { ThemeToggle } from './theme-toggle';
 
 const Header = () => {
     const [isContactModalOpen, setIsContactModalOpen] = useState(false);
@@ -32,6 +33,7 @@ const Header = () => {
                             Contact
                             <Mail className="h-4 w-4" />
                         </Button>
+                        <ThemeToggle />
                     </nav>
                     {/* Mobile Menu Button */}
                     <Sheet>
@@ -46,6 +48,7 @@ const Header = () => {
                                 <Link href="/portfolio" className="text-lg font-semibold">Projects</Link>
                                 <Link href="/aboutme" className="text-lg font-semibold">About Me</Link>
                                 <Link href="/content" className="text-lg font-semibold">Content</Link>
+                                <ThemeToggle />
                             </nav>
                         </SheetContent>
                     </Sheet>

--- a/src/components/hero-section.tsx
+++ b/src/components/hero-section.tsx
@@ -3,12 +3,19 @@
 import Image from 'next/image'
 import { Button } from './ui/button'
 import { Input } from './ui/input'
-import { useState } from 'react'
+import { useState, useEffect } from 'react'
+import { useTheme } from 'next-themes'
 import { AnimatedEmojiSequence } from './animated-emoji-sequence';
 
 
 const HeroSection = () => {
     const [email, setEmail] = useState('');
+    const { theme } = useTheme();
+    const [mounted, setMounted] = useState(false);
+
+    useEffect(() => {
+        setMounted(true);
+    }, []);
 
     const handleSubmit = async (e: React.FormEvent) => {
         e.preventDefault();
@@ -71,7 +78,7 @@ const HeroSection = () => {
                     {/* Image container */}
                     <div className="relative rounded-lg overflow-hidden">
                         <Image
-                            src="/matt-kuda-gemini.png"
+                            src={mounted && theme === 'dark' ? '/mattkuda-gradient2.png' : '/matt-kuda-gemini.png'}
                             alt="Matt Kuda"
                             width={500}
                             height={500}

--- a/src/components/theme-provider.tsx
+++ b/src/components/theme-provider.tsx
@@ -1,0 +1,8 @@
+'use client'
+
+import { ThemeProvider as NextThemesProvider } from 'next-themes'
+import type { ThemeProviderProps } from 'next-themes/dist/types'
+
+export function ThemeProvider({ children, ...props }: ThemeProviderProps) {
+  return <NextThemesProvider attribute="class" defaultTheme="light" {...props}>{children}</NextThemesProvider>
+}

--- a/src/components/theme-toggle.tsx
+++ b/src/components/theme-toggle.tsx
@@ -1,0 +1,28 @@
+'use client';
+
+import { useTheme } from 'next-themes'
+import { Moon, Sun } from 'lucide-react'
+import { Button } from './ui/button'
+import { useEffect, useState } from 'react'
+
+export function ThemeToggle() {
+  const { theme, setTheme } = useTheme()
+  const [mounted, setMounted] = useState(false)
+
+  useEffect(() => {
+    setMounted(true)
+  }, [])
+
+  if (!mounted) return null
+
+  return (
+    <Button
+      variant="ghost"
+      size="icon"
+      aria-label="Toggle theme"
+      onClick={() => setTheme(theme === 'dark' ? 'light' : 'dark')}
+    >
+      {theme === 'dark' ? <Sun className="h-5 w-5" /> : <Moon className="h-5 w-5" />}
+    </Button>
+  )
+}


### PR DESCRIPTION
## Summary
- add theme provider and toggle components
- wire theme toggle into header nav and mobile menu
- switch hero image depending on theme
- tweak dark mode body gradient
- include new dark-mode image
- fix missing newline characters and correct dark mode image path

## Testing
- `npm run lint` *(fails: next not found)*
- `npm run build` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_68407eaec9e88328aa0dade1f9858866