### PR TITLE
Add dark mode toggle with cursor.com-like dark theme

### DIFF
--- a/src/app/aboutme/page.tsx
+++ b/src/app/aboutme/page.tsx
@@ -19,7 +19,7 @@ export default function AboutMe() {
                         priority
                     />
                 </div>
-                <div className="space-y-6 text-zinc-800">
+                <div className="space-y-6 text-foreground">
                     <div className="text-xl md:text-2xl font-medium leading-relaxed">
                         Hi, I&apos;m Matt. I discovered both coding and fitness in high school and they&apos;ve been my two passions ever since.
                     </div>

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -27,25 +27,25 @@
   }
 
   .dark {
-    --background: 240 10% 3.9%;
-    --foreground: 0 0% 98%;
-    --card: 240 10% 3.9%;
-    --card-foreground: 0 0% 98%;
-    --popover: 240 10% 3.9%;
-    --popover-foreground: 0 0% 98%;
-    --primary: 0 0% 98%;
-    --primary-foreground: 240 5.9% 10%;
-    --secondary: 240 3.7% 15.9%;
-    --secondary-foreground: 0 0% 98%;
-    --muted: 240 3.7% 15.9%;
-    --muted-foreground: 240 5% 64.9%;
-    --accent: 240 3.7% 15.9%;
-    --accent-foreground: 0 0% 98%;
+    --background: 0 0% 7%;
+    --foreground: 0 0% 95%;
+    --card: 0 0% 10%;
+    --card-foreground: 0 0% 95%;
+    --popover: 0 0% 10%;
+    --popover-foreground: 0 0% 95%;
+    --primary: 0 0% 95%;
+    --primary-foreground: 0 0% 7%;
+    --secondary: 0 0% 14%;
+    --secondary-foreground: 0 0% 95%;
+    --muted: 0 0% 14%;
+    --muted-foreground: 0 0% 60%;
+    --accent: 0 0% 14%;
+    --accent-foreground: 0 0% 95%;
     --destructive: 0 62.8% 30.6%;
-    --destructive-foreground: 0 0% 98%;
-    --border: 240 3.7% 15.9%;
-    --input: 240 3.7% 15.9%;
-    --ring: 240 4.9% 83.9%;
+    --destructive-foreground: 0 0% 95%;
+    --border: 0 0% 18%;
+    --input: 0 0% 18%;
+    --ring: 0 0% 60%;
   }
 }
 
@@ -55,11 +55,15 @@
   }
 
   body {
-    @apply bg-white;
+    @apply bg-background text-foreground;
     background-image:
       radial-gradient(at 40% 20%, rgba(66, 133, 244, 0.1) 0px, transparent 50%),
       radial-gradient(at 80% 0%, rgba(155, 114, 203, 0.1) 0px, transparent 50%),
       radial-gradient(at 0% 50%, rgba(217, 101, 112, 0.1) 0px, transparent 50%);
     min-height: 100vh;
+  }
+
+  html.dark body {
+    background-image: none;
   }
 }

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -3,6 +3,7 @@ import localFont from "next/font/local";
 import "./globals.css";
 import Header from "../components/header";
 import { Footer } from "../components/footer";
+import { ThemeProvider } from "../components/theme-provider";
 
 const geistSans = localFont({
   src: "./fonts/GeistVF.woff",
@@ -26,11 +27,13 @@ export default function RootLayout({
   children: React.ReactNode;
 }>) {
   return (
-    <html lang="en">
+    <html lang="en" suppressHydrationWarning>
       <body className={`${geistSans.variable} ${geistMono.variable} antialiased`}>
-        <Header />
-        {children}
-        <Footer />
+        <ThemeProvider>
+          <Header />
+          {children}
+          <Footer />
+        </ThemeProvider>
       </body>
     </html>
   );

--- a/src/app/programs/[id]/page.tsx
+++ b/src/app/programs/[id]/page.tsx
@@ -30,7 +30,7 @@ export default function ProgramPage({ params }: Props) {
     };
 
     return (
-        <main className="min-h-screen bg-zinc-100 p-4">
+        <main className="min-h-screen bg-background p-4">
             <div className="container mx-auto max-w-7xl">
                 <div className="grid gap-8 md:grid-cols-2">
                     {/* Left Column - Image */}
@@ -59,11 +59,11 @@ export default function ProgramPage({ params }: Props) {
 
                         <div className="text-2xl font-bold">${program.price}</div>
 
-                        <p className="text-lg text-zinc-600">
+                        <p className="text-lg text-muted-foreground">
                             {program.description}
                         </p>
 
-                        <div className="rounded-md bg-zinc-200 p-4">
+                        <div className="rounded-md bg-secondary p-4">
                             <h3 className="font-semibold">Difficulty Level</h3>
                             <p>{program.difficulty}</p>
                         </div>

--- a/src/app/programs/page.tsx
+++ b/src/app/programs/page.tsx
@@ -9,7 +9,7 @@ export default function ProgramsPage() {
                 <h2 className="mb-4 text-center text-3xl font-bold">
                     Programs
                 </h2>
-                <p className="mb-8 text-lg text-center text-zinc-600">
+                <p className="mb-8 text-lg text-center text-muted-foreground">
                     Transform your fitness journey with my hand-crafted training programs
                 </p>
                 <div className="grid gap-6 grid-cols-2">

--- a/src/app/success/page.tsx
+++ b/src/app/success/page.tsx
@@ -8,15 +8,15 @@ import { Card, CardContent } from "@/components/ui/card"
 export default function SuccessPage() {
     return (
         <>
-            <main className="min-h-screen bg-zinc-100 p-4">
+            <main className="min-h-screen bg-background p-4">
                 <div className="container mx-auto max-w-3xl py-12">
                     <Card className="overflow-hidden">
                         <CardContent className="p-8 flex flex-col items-center">
                             <CheckCircle className="w-16 h-16 text-green-600 mb-6" />
-                            <h1 className="text-3xl font-bold text-zinc-900 mb-2 text-center">
+                            <h1 className="text-3xl font-bold text-foreground mb-2 text-center">
                                 Thank you for your purchase!
                             </h1>
-                            <p className="text-zinc-600 mb-8 text-center">
+                            <p className="text-muted-foreground mb-8 text-center">
                                 Check your email for your program details.
                             </p>
 
@@ -34,8 +34,8 @@ export default function SuccessPage() {
                                 </Button>
                             </div>
 
-                            <p className="mt-8 text-sm text-zinc-500 text-center">
-                                Need help? <Link href="/contact" className="text-zinc-900 underline underline-offset-4">Contact support</Link>
+                            <p className="mt-8 text-sm text-muted-foreground text-center">
+                                Need help? <Link href="/contact" className="text-foreground underline underline-offset-4">Contact support</Link>
                             </p>
                         </CardContent>
                     </Card>

--- a/src/components/footer.tsx
+++ b/src/components/footer.tsx
@@ -3,40 +3,40 @@ import { Twitter, Instagram, Linkedin } from "lucide-react";
 
 export function Footer() {
     return (
-        <footer className="border-t py-6 bg-zinc-50">
+        <footer className="border-t py-6 bg-secondary">
             <div className="container flex flex-col items-center justify-between gap-4 md:flex-row">
-                <p className="text-center text-sm leading-loose text-zinc-600">
+                <p className="text-center text-sm leading-loose text-muted-foreground">
                     © 2024 Matt Kuda. All rights reserved.
                 </p>
                 <div className="flex items-center gap-6">
                     {/* Legal Links */}
                     <nav className="flex gap-4">
-                        <Link href="#" className="text-sm text-zinc-600 underline-offset-4 hover:underline">
+                        <Link href="#" className="text-sm text-muted-foreground underline-offset-4 hover:underline hover:text-foreground">
                             Terms
                         </Link>
-                        <Link href="#" className="text-sm text-zinc-600 underline-offset-4 hover:underline">
+                        <Link href="#" className="text-sm text-muted-foreground underline-offset-4 hover:underline hover:text-foreground">
                             Privacy
                         </Link>
-                        <Link href="#" className="text-sm text-zinc-600 underline-offset-4 hover:underline">
+                        <Link href="#" className="text-sm text-muted-foreground underline-offset-4 hover:underline hover:text-foreground">
                             Contact
                         </Link>
                     </nav>
                     {/* Social Media Icons */}
-                    <div className="flex items-center gap-4 border-l border-zinc-200 pl-6">
+                    <div className="flex items-center gap-4 border-l border-border pl-6">
                         <Link href="https://twitter.com/mattkuda" target="_blank" rel="noopener noreferrer"
-                            className="text-zinc-600 hover:text-zinc-900 transition-colors">
+                            className="text-muted-foreground hover:text-foreground transition-colors">
                             <Twitter className="h-5 w-5" />
                         </Link>
                         <Link href="https://instagram.com/mattkuda" target="_blank" rel="noopener noreferrer"
-                            className="text-zinc-600 hover:text-zinc-900 transition-colors">
+                            className="text-muted-foreground hover:text-foreground transition-colors">
                             <Instagram className="h-5 w-5" />
                         </Link>
                         <Link href="https://linkedin.com/in/mattkuda" target="_blank" rel="noopener noreferrer"
-                            className="text-zinc-600 hover:text-zinc-900 transition-colors">
+                            className="text-muted-foreground hover:text-foreground transition-colors">
                             <Linkedin className="h-5 w-5" />
                         </Link>
                         <Link href="https://tiktok.com/@mattkuda" target="_blank" rel="noopener noreferrer"
-                            className="text-zinc-600 hover:text-zinc-900 transition-colors">
+                            className="text-muted-foreground hover:text-foreground transition-colors">
                             <svg
                                 xmlns="http://www.w3.org/2000/svg"
                                 viewBox="0 0 448 512"

--- a/src/components/free-program-modal.tsx
+++ b/src/components/free-program-modal.tsx
@@ -76,7 +76,7 @@ export function FreeProgramModal({ program, isOpen, onClose }: FreeProgramModalP
                         <h2 className="text-xl font-bold text-center mb-2">
                             Check your inbox!
                         </h2>
-                        <p className="text-zinc-600 text-center mb-6">
+                        <p className="text-muted-foreground text-center mb-6">
                             Your free program will arrive shortly after confirming your subscription.
                         </p>
                         <Button

--- a/src/components/header.tsx
+++ b/src/components/header.tsx
@@ -9,6 +9,7 @@ import {
 } from "@/components/ui/sheet"
 import { useState } from 'react';
 import { ContactModal } from './contact-modal';
+import { ThemeToggle } from './theme-toggle';
 
 const Header = () => {
     const [isContactModalOpen, setIsContactModalOpen] = useState(false);
@@ -32,14 +33,17 @@ const Header = () => {
                             Contact
                             <Mail className="h-4 w-4" />
                         </Button>
+                        <ThemeToggle />
                     </nav>
-                    {/* Mobile Menu Button */}
-                    <Sheet>
-                        <SheetTrigger asChild>
-                            <Button variant="ghost" className="ml-4 md:hidden" aria-label="Open menu">
-                                <Menu className="h-6 w-6" />
-                            </Button>
-                        </SheetTrigger>
+                    {/* Mobile Theme Toggle & Menu Button */}
+                    <div className="flex items-center md:hidden">
+                        <ThemeToggle />
+                        <Sheet>
+                            <SheetTrigger asChild>
+                                <Button variant="ghost" className="ml-2" aria-label="Open menu">
+                                    <Menu className="h-6 w-6" />
+                                </Button>
+                            </SheetTrigger>
                         <SheetContent side="right">
                             <nav className="flex flex-col gap-4">
                                 <Link href="/programs" className="text-lg font-semibold">Programs</Link>
@@ -48,7 +52,8 @@ const Header = () => {
                                 <Link href="/content" className="text-lg font-semibold">Content</Link>
                             </nav>
                         </SheetContent>
-                    </Sheet>
+                        </Sheet>
+                    </div>
                 </div>
             </div>
             <ContactModal isOpen={isContactModalOpen} onClose={() => setIsContactModalOpen(false)} />

--- a/src/components/hero-section.tsx
+++ b/src/components/hero-section.tsx
@@ -41,7 +41,7 @@ const HeroSection = () => {
                         placeholder="Your email address"
                         value={email}
                         onChange={(e) => setEmail(e.target.value)}
-                        className="h-12 text-lg placeholder:text-lg px-6 bg-white"
+                        className="h-12 text-lg placeholder:text-lg px-6 bg-background"
                     />
                     <div className="relative group">
                         <div className="absolute inset-0 bg-gradient-to-r from-[#4285f4] via-[#9b72cb] to-[#d96570] rounded-md opacity-100 group-hover:opacity-0 transition-opacity duration-300" />

--- a/src/components/newsletter-section.tsx
+++ b/src/components/newsletter-section.tsx
@@ -23,7 +23,7 @@ export default function NewsletterSection() {
             <div className="container">
                 <div className="mx-auto max-w-2xl text-center">
                     <h2 className="mb-4 text-3xl font-bold">Stay Updated</h2>
-                    <p className="mb-8 text-zinc-600">
+                    <p className="mb-8 text-muted-foreground">
                         Sign up for my newsletter to receive tech news, fitness tips, and the content I find most interesting each week.
                     </p>
 

--- a/src/components/portfolio-card.tsx
+++ b/src/components/portfolio-card.tsx
@@ -82,7 +82,7 @@ export function PortfolioCard({ title, videoUrl, description, image, demoUrl, co
                     {technologies.map((tech) => (
                         <span
                             key={tech}
-                            className="px-3 py-1 bg-zinc-200 rounded-full text-sm text-zinc-800"
+                            className="px-3 py-1 bg-secondary rounded-full text-sm text-secondary-foreground"
                         >
                             {tech}
                         </span>

--- a/src/components/program-details.tsx
+++ b/src/components/program-details.tsx
@@ -20,7 +20,7 @@ export function ProgramDetails({ program }: ProgramDetailsProps) {
     };
 
     return (
-        <div className="min-h-screen bg-zinc-100 py-12">
+        <div className="min-h-screen bg-background py-12">
             <div className="container">
                 <div className="grid gap-8 md:grid-cols-2">
                     {/* Left Column - Image */}
@@ -49,11 +49,11 @@ export function ProgramDetails({ program }: ProgramDetailsProps) {
 
                         <div className="text-2xl font-bold">${program.price}</div>
 
-                        <p className="text-lg text-zinc-600">
+                        <p className="text-lg text-muted-foreground">
                             {program.description}
                         </p>
 
-                        <div className="rounded-md bg-zinc-200 p-4">
+                        <div className="rounded-md bg-secondary p-4">
                             <h3 className="font-semibold">Difficulty Level</h3>
                             <p>{program.difficulty}</p>
                         </div>

--- a/src/components/programs-section.tsx
+++ b/src/components/programs-section.tsx
@@ -35,7 +35,7 @@ export function ProgramsSection() {
                 <h2 className="mb-4 text-center text-3xl font-bold">
                     Training Programs
                 </h2>
-                <p className="mb-8 text-lg text-center text-zinc-600">
+                <p className="mb-8 text-lg text-center text-muted-foreground">
                     Transform your fitness journey with my hand-crafted training programs
                 </p>
                 <motion.div

--- a/src/components/theme-provider.tsx
+++ b/src/components/theme-provider.tsx
@@ -1,0 +1,55 @@
+'use client'
+
+import { createContext, useContext, useEffect, useState } from 'react'
+
+type Theme = 'light' | 'dark'
+
+interface ThemeContextType {
+  theme: Theme
+  toggleTheme: () => void
+}
+
+const ThemeContext = createContext<ThemeContextType | undefined>(undefined)
+
+export function ThemeProvider({ children }: { children: React.ReactNode }) {
+  const [theme, setTheme] = useState<Theme>('light')
+  const [mounted, setMounted] = useState(false)
+
+  useEffect(() => {
+    setMounted(true)
+    const savedTheme = localStorage.getItem('theme') as Theme | null
+    if (savedTheme) {
+      setTheme(savedTheme)
+    }
+  }, [])
+
+  useEffect(() => {
+    if (!mounted) return
+
+    const root = document.documentElement
+    if (theme === 'dark') {
+      root.classList.add('dark')
+    } else {
+      root.classList.remove('dark')
+    }
+    localStorage.setItem('theme', theme)
+  }, [theme, mounted])
+
+  const toggleTheme = () => {
+    setTheme(prev => prev === 'light' ? 'dark' : 'light')
+  }
+
+  return (
+    <ThemeContext.Provider value={{ theme, toggleTheme }}>
+      {children}
+    </ThemeContext.Provider>
+  )
+}
+
+export function useTheme() {
+  const context = useContext(ThemeContext)
+  if (context === undefined) {
+    throw new Error('useTheme must be used within a ThemeProvider')
+  }
+  return context
+}

--- a/src/components/theme-toggle.tsx
+++ b/src/components/theme-toggle.tsx
@@ -1,0 +1,22 @@
+'use client'
+
+import { Moon, Sun } from 'lucide-react'
+import { useTheme } from './theme-provider'
+
+export function ThemeToggle() {
+  const { theme, toggleTheme } = useTheme()
+
+  return (
+    <button
+      onClick={toggleTheme}
+      className="p-2 rounded-md hover:bg-accent transition-colors"
+      aria-label={theme === 'light' ? 'Switch to dark mode' : 'Switch to light mode'}
+    >
+      {theme === 'light' ? (
+        <Moon className="h-5 w-5 text-foreground" />
+      ) : (
+        <Sun className="h-5 w-5 text-foreground" />
+      )}
+    </button>
+  )
+}


### PR DESCRIPTION
- Create ThemeProvider context for managing theme state with localStorage persistence
- Create minimal ThemeToggle component with sun/moon icons (lucide-react)
- Update globals.css with cursor.com-inspired dark theme colors (no gradient bg in dark mode)
- Add toggle to header (visible on both desktop and mobile)
- Update all components to use semantic color classes instead of hardcoded zinc colors
- Theme persists across page refreshes via localStorage